### PR TITLE
Separate out name/postcode for VOA + charity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Test cases are held in tab-separated format files with the following columns:
 
 - test — an identifier for the test case which should be unique across all tests
 - name — the addressee or name of the business (if separable)
-- text — address text to be matched, newlines should be encoded as '\n'
+- text — address text to be matched, newlines should be encoded as '\n' (only include name or postcode if can't be stored in separate field)
 - postcode — an optional, separate postcode (if separable)
 - uprns — one or more UPRN values in decimal which could match the address, separated by semicolon ';'
 - notes — an explanation of the test

--- a/bulk/charity-commission/addresses.py
+++ b/bulk/charity-commission/addresses.py
@@ -7,8 +7,8 @@ import io
 
 #address_fields = ["EstablishmentName", "Street", "Locality", "Address3", "Town", "County (name)", "Postcode"]
 field_names = [ 'regno', 'subno', 'name', 'orgtype', 'gd', 'aob', 'aob_defined', 'nhs', 'ha_no', 'corr', 'add1', 'add2', 'add3', 'add4', 'add5', 'postcode', 'phone', 'fax' ]
-address_fields = [ 'name', 'add1', 'add2', 'add3', 'add4', 'add5', 'postcode' ]
-output_fields = [ "test", "text" ]
+address_fields = [ 'add1', 'add2', 'add3', 'add4', 'add5' ]
+output_fields = [ "test", "name", "text", "postcode" ]
 sep = "\t"
 
 
@@ -48,7 +48,14 @@ if __name__ == '__main__':
         output = {}
         output['test'] = "charity:" + items['regno']
 
+        output['name'] = items['name']
+
         output['text'] = ",".join([items[field] for field in address_fields if items[field] != ""])
         output['text'] = re.sub(",+", ", ", output['text'])
+        if output['text'] == "":
+            continue
+
+        output['postcode'] = items['postcode']
 
         print(sep.join([output[field] for field in output_fields]))
+

--- a/bulk/voa/addresses.py
+++ b/bulk/voa/addresses.py
@@ -5,7 +5,7 @@ import csv
 import re
 import io
 
-output_fields = [ "test", "text" ]
+output_fields = [ "test", "text", "postcode" ]
 sep = "\t"
 
 if __name__ == '__main__':
@@ -18,6 +18,7 @@ if __name__ == '__main__':
     for row in csv.DictReader(input_stream, delimiter=" ", quotechar='"'):
         item = {}
         item['test'] = "voa:" + row['uarn']
-        item['text'] = row['propaddr'] + ", " + row['postcde']
+        item['text'] = row['propaddr']
+        item['postcode'] = row['postcde']
 
         print(sep.join([item[field] for field in output_fields]))


### PR DESCRIPTION
To comply with `addresses.tsv` specification.

Added note to README that `name/postcode` should not be included in `text` if they can be split out.

For charity, don't write rows with no address.
