### PR TITLE
Fix invocations of programs in $PWD

### DIFF
--- a/bulk/food-hygiene/Makefile
+++ b/bulk/food-hygiene/Makefile
@@ -1,11 +1,11 @@
 INDEX_URL="http://ratings.food.gov.uk/open-data/"
 
 addresses.tsv:	addresses.sh addresses.xsl
-	addresses.sh > $@
+	./addresses.sh > $@
 
 download:
 	mkdir -p cache
-	download.sh $(INDEX_URL) cache/
+	./download.sh $(INDEX_URL) cache/
 
 clean:
 	rm -rf cache

--- a/bulk/price-paid/Makefile
+++ b/bulk/price-paid/Makefile
@@ -2,7 +2,7 @@
 PP_COMPLETE_URL='http://prod.publicdata.landregistry.gov.uk.s3-website-eu-west-1.amazonaws.com/pp-complete.csv'
 
 addresses.tsv:	cache/pp-complete.csv addresses.py
-	addresses.py < cache/pp-complete.csv > $@
+	./addresses.py < cache/pp-complete.csv > $@
 
 # download price paid dataset
 # - contains invalid UTF-8 characters ..


### PR DESCRIPTION
These assume `$PATH` contains `.`, which is not a default configuration.